### PR TITLE
Tweak for v0.14

### DIFF
--- a/fluent-plugin-filter_codec.gemspec
+++ b/fluent-plugin-filter_codec.gemspec
@@ -15,5 +15,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
+  spec.add_development_dependency "test-unit", ">= 3.2.0"
   spec.add_development_dependency "fluentd"
 end

--- a/fluent-plugin-filter_codec.gemspec
+++ b/fluent-plugin-filter_codec.gemspec
@@ -16,5 +16,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "test-unit", ">= 3.2.0"
-  spec.add_development_dependency "fluentd"
+  spec.add_dependency "fluentd", ">= 0.12.0"
 end

--- a/lib/fluent/plugin/out_filter_codec.rb
+++ b/lib/fluent/plugin/out_filter_codec.rb
@@ -56,11 +56,11 @@ module Fluent
         return
       end
 
-      record[@output_field] = process(value_in, @codec) || value_in
+      record[@output_field] = process_filter(value_in, @codec) || value_in
     end
 
     private
-    def process(value, codec)
+    def process_filter(value, codec)
       return @codec_functions[codec].call(value)
     rescue
       return @error_value

--- a/lib/fluent/plugin/out_filter_codec.rb
+++ b/lib/fluent/plugin/out_filter_codec.rb
@@ -43,7 +43,7 @@ module Fluent
       es.each { |time, record|
         t = tag.dup
         filter_record(t, time, record)
-        Engine.emit(t, time, record)
+        router.emit(t, time, record)
       }
 
       chain.next


### PR DESCRIPTION
Because this plugin is not v0.14 ready.

* `#process` is overridden unexpectedly
* `router#emit` is encouraged to use in v0.14