### PR TITLE
Add filter version of filter_codec plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,48 @@
 # fluent-plugin-filter_codec
 
+## CodecFilter
+
+Fluentd filter plugin which converts a field in the record.
+Codec can be:
+ 'base64-encode' and 'base64-decode' see RFC 4648
+ 'urlsafe64-encode' and 'urlsafe64-decode' replacing '+/' by '-_' and making '=' padding optional
+
+### Usage
+
+```
+<filter test>
+    type codec
+    codec base64-decode
+    field key1
+    output_field key2
+</filter>
+```
+
+Example of records :
+```
+{
+    'key1' => "Tmljb2xhcyBDYWdl",
+    'foo' => "bar"
+}
+```
+... will output (unchanged) :
+```
+{
+    'key1' => "Nicolas Cage",
+    'foo' => "bar"
+}
+```
+
+You can omit 'output_field' so 'field' value will be replaced by output value.
+
+## FilterCodecOutput
+
 Fluentd output plugin which converts a field in the record.
 Codec can be:
  'base64-encode' and 'base64-decode' see RFC 4648
  'urlsafe64-encode' and 'urlsafe64-decode' replacing '+/' by '-_' and making '=' padding optional
 
-## Usage
+### Usage
 
 ```
 <match test>

--- a/fluent-plugin-filter_codec.gemspec
+++ b/fluent-plugin-filter_codec.gemspec
@@ -15,5 +15,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
+  spec.add_development_dependency "test-unit", ">= 3.2.0"
   spec.add_development_dependency "fluentd"
 end

--- a/fluent-plugin-filter_codec.gemspec
+++ b/fluent-plugin-filter_codec.gemspec
@@ -16,5 +16,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "test-unit", ">= 3.2.0"
-  spec.add_development_dependency "fluentd"
+  spec.add_dependency "fluentd", ">= 0.12.0"
 end

--- a/lib/fluent/plugin/filter_codec.rb
+++ b/lib/fluent/plugin/filter_codec.rb
@@ -1,0 +1,47 @@
+# coding: utf-8
+require "base64"
+require "fluent/plugin/filter_codec_support"
+
+module Fluent
+  class CodecFilter < Filter
+    include Fluent::FilterCodecSupport
+
+    Fluent::Plugin.register_filter('codec', self)
+
+    config_param :field, :string, :default => nil
+    config_param :output_field, :string, :default => nil
+    config_param :codec, :string, :default => nil
+    config_param :error_value, :string, :default => ""
+
+
+    def configure(conf)
+      super
+
+      # Put new functions here
+      @codec_functions = {
+        'base64-decode' => method(:base64_decode),
+        'base64-encode' => method(:base64_encode),
+        'urlsafe64-decode' => method(:urlsafe64_decode),
+        'urlsafe64-encode' => method(:urlsafe64_encode)
+      }
+
+      if (field.nil? || codec.nil?)
+        raise ConfigError, "filter_codec: Both 'field', and 'codec' are required to be set."
+      end
+
+      if (@codec_functions[codec].nil?)
+        raise ConfigError, "filter_codec: Unknown codec : " + codec
+      end
+
+      @output_field = output_field || field
+    end
+
+    def filter(tag, time, record)
+      value_in = record[@field]
+      return nil if (value_in.nil?)
+
+      record[@output_field] = process_filter(value_in, @codec) || value_in
+      record
+    end
+  end
+end

--- a/lib/fluent/plugin/filter_codec_support.rb
+++ b/lib/fluent/plugin/filter_codec_support.rb
@@ -1,0 +1,31 @@
+module Fluent
+  module FilterCodecSupport
+    def process_filter(value, codec)
+      return @codec_functions[codec].call(value)
+    rescue
+      return @error_value
+    end
+
+    def base64_decode(value)
+      return Base64.strict_decode64(value)
+    end
+
+    def base64_encode(value)
+      return Base64.strict_encode64(value)
+    end
+
+    def add_one_padding(str)
+      return (0 != str.length % 4) ? str + '=' : str
+    end
+
+    def urlsafe64_decode(value)
+      # Add up to 2 '=' padding
+      return Base64.urlsafe_decode64(add_one_padding(add_one_padding(value)))
+    end
+
+    def urlsafe64_encode(value)
+      # Remove up to 2 '=' padding
+      return Base64.urlsafe_encode64(value).chomp('=').chomp('=')
+    end
+  end
+end

--- a/lib/fluent/plugin/out_filter_codec.rb
+++ b/lib/fluent/plugin/out_filter_codec.rb
@@ -1,9 +1,11 @@
 # coding: utf-8
 require "base64"
+require "fluent/plugin/filter_codec_support"
 
 module Fluent
   class FilterCodecOutput < Output
     include Fluent::HandleTagNameMixin
+    include Fluent::FilterCodecSupport
 
     Fluent::Plugin.register_output('filter_codec', self)
 
@@ -57,35 +59,6 @@ module Fluent
       end
 
       record[@output_field] = process_filter(value_in, @codec) || value_in
-    end
-
-    private
-    def process_filter(value, codec)
-      return @codec_functions[codec].call(value)
-    rescue
-      return @error_value
-    end
-
-    def base64_decode(value)
-      return Base64.strict_decode64(value)
-    end
-
-    def base64_encode(value)
-      return Base64.strict_encode64(value)
-    end
-
-    def add_one_padding(str)
-      return (0 != str.length % 4) ? str + '=' : str
-    end
-
-    def urlsafe64_decode(value)
-      # Add up to 2 '=' padding
-      return Base64.urlsafe_decode64(add_one_padding(add_one_padding(value)))
-    end
-
-    def urlsafe64_encode(value)
-      # Remove up to 2 '=' padding
-      return Base64.urlsafe_encode64(value).chomp('=').chomp('=')
     end
   end
 end

--- a/lib/fluent/plugin/out_filter_codec.rb
+++ b/lib/fluent/plugin/out_filter_codec.rb
@@ -56,11 +56,11 @@ module Fluent
         return
       end
 
-      record[@output_field] = process(value_in, @codec) || value_in
+      record[@output_field] = process_filter(value_in, @codec) || value_in
     end
 
     private
-    def process(value, codec)
+    def process_filter(value, codec)
       return @codec_functions[codec].call(value)
     rescue
       return @error_value

--- a/lib/fluent/plugin/out_filter_codec.rb
+++ b/lib/fluent/plugin/out_filter_codec.rb
@@ -43,7 +43,7 @@ module Fluent
       es.each { |time, record|
         t = tag.dup
         filter_record(t, time, record)
-        Engine.emit(t, time, record)
+        router.emit(t, time, record)
       }
 
       chain.next

--- a/test/plugin/test_filter_codec.rb
+++ b/test/plugin/test_filter_codec.rb
@@ -1,0 +1,227 @@
+# coding: utf-8
+
+require 'test_helper'
+require 'fluent/plugin/filter_codec'
+
+class CodecFilterTest < Test::Unit::TestCase
+  def setup
+    Fluent::Test.setup
+  end
+
+  def create_driver(conf, tag = 'test')
+    Fluent::Test::FilterTestDriver.new(
+      Fluent::CodecFilter, tag
+    ).configure(conf)
+  end
+
+  def test_configure_on_success
+
+    # All set
+    d = create_driver(%[
+      field key1
+      output_field key2
+      codec base64-decode
+      error_value foo
+    ])
+
+    assert_equal 'key1',    d.instance.field
+    assert_equal 'key2', d.instance.output_field
+    assert_equal 'base64-decode', d.instance.codec
+    assert_equal 'foo', d.instance.error_value
+
+    # output_field and error_value missing
+    d = create_driver(%[
+      field key1
+      codec base64-decode
+    ])
+
+    assert_equal 'key1',    d.instance.field
+    assert_equal 'key1', d.instance.output_field
+    assert_equal 'base64-decode', d.instance.codec
+    assert_equal '', d.instance.error_value
+
+  end
+
+  def test_configure_on_failure
+    # when mandatory keys not set
+    assert_raise(Fluent::ConfigError) do
+      create_driver(%[
+        blah blah
+      ])
+    end
+
+    # when 'field' is missing
+    assert_raise(Fluent::ConfigError) do
+      create_driver(%[
+      output_field key2
+      codec base64-decode
+    ])
+    end
+
+    # when unknown codec
+    assert_raise(Fluent::ConfigError) do
+      create_driver(%[
+      field key1
+      output_field key2
+      codec unknown-codec
+    ])
+    end
+
+  end
+
+  def test_emit_with_base64_decode
+    d = create_driver(%[
+      field key1
+      output_field key2
+      codec base64-decode
+    ])
+
+    record = {
+      'key1' => "Tmljb2xhcyBDYWdl",
+      'foo' => "bar"
+    }
+
+    d.run { d.emit(record) }
+    emits = d.filtered_as_array
+
+    assert_equal 1,           emits.count
+    assert_equal 'test', emits[0][0]
+    assert_equal 'Nicolas Cage',emits[0][2]['key2']
+  end
+
+  def test_emit_with_base64_decode_and_no_output
+    d = create_driver(%[
+      field key1
+      codec base64-decode
+    ])
+
+    record = {
+      'key1' => "Tmljb2xhcyBDYWdl",
+      'foo' => "bar"
+    }
+
+    d.run { d.emit(record) }
+    emits = d.filtered_as_array
+
+    assert_equal 1,           emits.count
+    assert_equal 'test', emits[0][0]
+    assert_equal 'Nicolas Cage',emits[0][2]['key1']
+  end
+
+  def test_emit_with_base64_encode
+    d = create_driver(%[
+      field key1
+      output_field key2
+      codec base64-encode
+    ])
+
+    record = {
+      'key1' => "Nicolas Cage",
+      'foo' => "bar"
+    }
+
+    d.run { d.emit(record) }
+    emits = d.filtered_as_array
+
+    assert_equal 1,           emits.count
+    assert_equal 'test', emits[0][0]
+    assert_equal 'Tmljb2xhcyBDYWdl',emits[0][2]['key2']
+  end
+
+  def test_emit_with_base64_decode_error_not_set
+    d = create_driver(%[
+      field key1
+      output_field key2
+      codec base64-decode
+    ])
+
+    record = {
+      'key1' => "YmFkdmFsdWU",
+      'foo' => "bar"
+    }
+
+    d.run { d.emit(record) }
+    emits = d.filtered_as_array
+
+    assert_equal 1,           emits.count
+    assert_equal 'test', emits[0][0]
+    assert_equal '',emits[0][2]['key2']
+  end
+
+  def test_emit_with_base64_decode_error_set
+    d = create_driver(%[
+      field key1
+      output_field key2
+      codec base64-decode
+      error_value foo
+    ])
+
+    record = {
+      'key1' => "YmFkdmFsdWU",
+      'foo' => "bar"
+    }
+
+    d.run { d.emit(record) }
+    emits = d.filtered_as_array
+
+    assert_equal 1,           emits.count
+    assert_equal 'test', emits[0][0]
+    assert_equal 'foo',emits[0][2]['key2']
+  end
+
+  data("base" => {"key1" => "Tmk-b2w_c8K_Q8O-Zy_CqSBDYWdl",
+                  "expected" => "Ni>ol?s¿Cþg/© Cage".force_encoding("ASCII-8BIT")},
+       "remote the last character" => {"key1" => "Tmk-b2w_c8K_Q8O-Zy_CqSBDYWc",
+                                       "expected" => "Ni>ol?s¿Cþg/© Cag".force_encoding("ASCII-8BIT")},
+       "remote the last two characters" => {"key1" => "Tmk-b2w_c8K_Q8O-Zy_CqSBDYQ",
+                                            "expected" => "Ni>ol?s¿Cþg/© Ca".force_encoding("ASCII-8BIT")}
+      )
+  def test_emit_with_urlsafe64_decode(data)
+    d = create_driver(%[
+      field key1
+      output_field key2
+      codec urlsafe64-decode
+    ])
+
+    record = {
+      'key1' => data["key1"],
+      'foo' => "bar"
+    }
+    expect = "Ni>ol?s¿Cþg/© Cage".force_encoding("ASCII-8BIT")
+
+    d.run { d.emit(record) }
+    emits = d.filtered_as_array
+
+    assert_equal 1,           emits.count
+    assert_equal 'test', emits[0][0]
+    assert_equal data["expected"],emits[0][2]['key2']
+  end
+
+  data("base" => {"key1" => "Ni>ol?s¿Cþg/© Cage".force_encoding("ASCII-8BIT"),
+                  "expected" => "Tmk-b2w_c8K_Q8O-Zy_CqSBDYWdl"},
+       "remote the last character" => {"key1" => "Ni>ol?s¿Cþg/© Cag".force_encoding("ASCII-8BIT"),
+                                       "expected" => "Tmk-b2w_c8K_Q8O-Zy_CqSBDYWc"},
+       "remote the last two characters" => {"key1" => "Ni>ol?s¿Cþg/© Ca".force_encoding("ASCII-8BIT"),
+                                           "expected" => "Tmk-b2w_c8K_Q8O-Zy_CqSBDYQ"}
+      )
+  def test_emit_with_urlsafe64_encode(data)
+    d = create_driver(%[
+      field key1
+      output_field key2
+      codec urlsafe64-encode
+    ])
+
+    record = {
+      'key1' => data["key1"],
+      'foo' => "bar"
+    }
+
+    d.run { d.emit(record) }
+    emits = d.filtered_as_array
+
+    assert_equal 1,           emits.count
+    assert_equal 'test', emits[0][0]
+    assert_equal data["expected"],emits[0][2]['key2']
+  end
+
+end


### PR DESCRIPTION
Please review after #2 is merged.

---

It would be nice to provide filter version of filter_codec.
Because this plugin feature can be implemented in filter plugin mechanism and filter plugin can migrate to use v0.14 API more easily than non-buffered output plugin.